### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ dash
 dash-html-components
 dash-core-components
 dash-table
+pandas


### PR DESCRIPTION
hotfix
ImportError: Plotly express requires pandas to be installed.